### PR TITLE
Hyva compatibility update for v3.19.1

### DIFF
--- a/src/view/frontend/layout/hyva_checkout_cart_index.xml
+++ b/src/view/frontend/layout/hyva_checkout_cart_index.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright Extend (c) 2025. All rights reserved.
+  ~ See Extend-COPYING.txt for license details.
+  -->
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="checkout.cart.totals.container">
+            <block name="extend.checkout.cart.totals.shipping.protection"
+                   template="Extend_HyvaIntegration::checkout/cart/totals/shipping-protection.phtml"
+                   ifconfig="extend_plans/shipping_protection/enable">
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/src/view/frontend/templates/cart/minicart-simple-offer.phtml
+++ b/src/view/frontend/templates/cart/minicart-simple-offer.phtml
@@ -25,18 +25,21 @@
     </div>
 
     <script>
-
+        if (!window.minicartSimpleOffer){
+            initCartPage();
+        }
+        function initCartPage() {
             const minicartSelector = '[data-block="minicart"]'
             const productItemSelector = '.items-start'
             const itemDetailsSelector = '.price-excluding-tax'
             const simpleOfferClass = 'extend-minicart-simple-offer'
 
-            window.minicartSimpleOffer =  function() {
+            window.minicartSimpleOffer = function () {
 
                 return {
                     customerData: {},
 
-                    initMinicartSimpleOffer(event ) {
+                    initMinicartSimpleOffer(event) {
 
                         const minicartConfig = [{
                             extendStoreUuid: "<?= $block->getData('viewModel')->getExtendStoreUuid() ?>",
@@ -49,19 +52,19 @@
 
                         'use strict';
 
-                        if (!toggle && event.detail.data){
+                        if (!toggle && event.detail.data) {
                             this.customerData = event.detail.data;
                         }
 
                         if (!(window.Extend || window.ExtendMagento)) return;
 
-                        if (toggle && event.detail && !event.detail.isOpen  ) return;
+                        if (toggle && event.detail && !event.detail.isOpen) return;
 
                         const cartUtils = window.cart_utils(this.customerData);
 
                         function handleUpdate() {
                             let cartItems = cartUtils.getCartItems();
-                            for(let item in cartItems ) {
+                            for (let item in cartItems) {
                                 const cartItem = cartItems[item];
                                 const itemContainerElem = document.querySelectorAll(productItemSelector)[item]
                                 const isWarrantyInCart = ExtendMagento.warrantyInCart({
@@ -69,14 +72,14 @@
                                     lineItems: cartItems,
                                 })
                                 const simpleOfferElemId = `extend-minicart-simple-offer-${cartItem.item_id}`
-                                const  existingSimpleOfferElem = itemContainerElem ? itemContainerElem.querySelector('.extend-minicart-simple-offer')  :false;
+                                const existingSimpleOfferElem = itemContainerElem ? itemContainerElem.querySelector('.extend-minicart-simple-offer') : false;
 
-                                if (existingSimpleOfferElem){
+                                if (existingSimpleOfferElem) {
                                     existingSimpleOfferElem.remove()
                                 }
                                 if (cartItem.product_sku === 'extend-protection-plan'
-                                        || cartItem.product_sku === 'xtd-pp-pln'
-                                        || isWarrantyInCart ){
+                                    || cartItem.product_sku === 'xtd-pp-pln'
+                                    || isWarrantyInCart) {
                                     continue;
                                 }
 
@@ -100,7 +103,7 @@
                             }
                         }
 
-                        function  getProductQuantity  (cartItems, product) {
+                        function getProductQuantity(cartItems, product) {
                             let quantity = 1
 
                             const matchedCartItem = cartItems.find(
@@ -111,43 +114,46 @@
                             return quantity
                         }
 
-                         function addToCart (opts) {
-                             const {plan, product, quantity} = opts
+                        function addToCart(opts) {
+                            const {plan, product, quantity} = opts
 
-                             if (plan && product) {
-                                 const {planId, price, term, title, coverageType, offerId} = plan
-                                 const {id: productId, price: listPrice} = product
+                            if (plan && product) {
+                                const {planId, price, term, title, coverageType, offerId} = plan
+                                const {id: productId, price: listPrice} = product
 
-                                 const planToUpsert = {
-                                     planId,
-                                     price,
-                                     term,
-                                     title,
-                                     coverageType,
-                                 }
-                                 const cartItems = cartUtils
-                                     .getCartItems()
-                                     .map(cartUtils.mapToExtendCartItem)
+                                const planToUpsert = {
+                                    planId,
+                                    price,
+                                    term,
+                                    title,
+                                    coverageType,
+                                }
+                                const cartItems = cartUtils
+                                    .getCartItems()
+                                    .map(cartUtils.mapToExtendCartItem)
 
-                                 ExtendMagento.upsertProductProtection({
-                                     plan: planToUpsert,
-                                     cartItems,
-                                     productId,
-                                     listPrice,
-                                     offerId,
-                                     quantity: quantity ?? getProductQuantity(cartItems, product),
-                                 }).finally(()=> {
-                                     cartUtils.refreshMiniCart();
-                                 })
-                             }
-                         }
+                                ExtendMagento.upsertProductProtection({
+                                    plan: planToUpsert,
+                                    cartItems,
+                                    productId,
+                                    listPrice,
+                                    offerId,
+                                    quantity: quantity ?? getProductQuantity(cartItems, product),
+                                }).finally(() => {
+                                    cartUtils.refreshMiniCart();
+                                })
+                            }
+                        }
 
-                         return function (config) {
-                             setTimeout(()=>{ handleUpdate()  }, 1000)
-                         }.bind(window.Extend, window.ExtendMagento)();
+                        return function (config) {
+                            setTimeout(() => {
+                                handleUpdate()
+                            }, 1000)
+                        }.bind(window.Extend, window.ExtendMagento)();
                     }
                 }
             }
+        }
  </script>
 
 <?php endif; ?>

--- a/src/view/frontend/templates/checkout/cart/totals/shipping-protection.phtml
+++ b/src/view/frontend/templates/checkout/cart/totals/shipping-protection.phtml
@@ -1,0 +1,5 @@
+<!--
+  ~ Copyright Extend (c) 2025. All rights reserved.
+  ~ See Extend-COPYING.txt for license details.
+  ~ Hyva override of checkout/carts/totals/shipping_protection
+  -->


### PR DESCRIPTION
Some code needed to be updated to allow the shipping protection logic to run on hyva's cart, as it was throwing console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new block for displaying shipping protection totals on the Hyvä checkout cart page, which appears based on configuration settings.

* **Bug Fixes**
  * Improved minicart offer logic to ensure it initializes only once, preventing potential duplicate initializations.

* **Chores**
  * Added a placeholder template file for future shipping protection display in the checkout cart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->