### PR TITLE
Update product-protection-offer.phtml

### DIFF
--- a/src/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
+++ b/src/view/frontend/templates/catalog/product/view/type/grouped/product-protection-offer.phtml
@@ -92,7 +92,11 @@
                 const getProductQuantity = function (productOffer) {
                     let quantity = 1
                     const quantityInput = document.querySelector('#super_group\\['+productOffer+'\\]');
-                    if (quantityInput) quantity = parseInt(quantityInput.value)
+                    if (quantityInput) {
+                        quantity = parseInt(quantityInput.value)
+                    }else {
+                        return null
+                    }
                     return quantity
                 }
 
@@ -158,29 +162,31 @@
                                     const selectedPlan = buttonInstance.getPlanSelection()
 
                                     // If a plan is selected, add it to the cart
-                                    if (selectedPlan && quantity > 0) {
-                                        const {planId, price, term, title, coverageType, offerId} = selectedPlan;
-                                        const {
-                                            selectedProductSku: productId,
-                                            selectedPrice: listPrice,
-                                        } = selectedProduct
+                                    if (quantity){
+                                        if (selectedPlan && quantity >0) {
+                                            const {planId, price, term, title, coverageType, offerId} = selectedPlan;
+                                            const {
+                                                selectedProductSku: productId,
+                                                selectedPrice: listPrice,
+                                            } = selectedProduct
 
-                                        const planToUpsert = {
-                                            planId,
-                                            price,
-                                            term,
-                                            title,
-                                            coverageType,
+                                            const planToUpsert = {
+                                                planId,
+                                                price,
+                                                term,
+                                                title,
+                                                coverageType,
+                                            }
+
+                                            await ExtendMagento.upsertProductProtection({
+                                                plan: planToUpsert,
+                                                cartItems,
+                                                productId,
+                                                listPrice,
+                                                offerId,
+                                                quantity,
+                                            })
                                         }
-
-                                        await ExtendMagento.upsertProductProtection({
-                                            plan: planToUpsert,
-                                            cartItems,
-                                            productId,
-                                            listPrice,
-                                            offerId,
-                                            quantity,
-                                        })
                                     }
                             }
                             index++;


### PR DESCRIPTION
account for out of stock items, not presenting a #super_group[]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents protection plans from being added to the cart for grouped products when quantity is not set or is zero.
  * Quantity handling is now accurate: if no quantity is provided, it’s treated as not selected rather than defaulting to one.
  * Improves add-to-cart reliability for product protection offers by only proceeding when a positive quantity and a plan are selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->