### PR TITLE
Update product-protection-simple-offer.phtml

### DIFF
--- a/src/view/frontend/templates/cart/item/renderer/actions/product-protection-simple-offer.phtml
+++ b/src/view/frontend/templates/cart/item/renderer/actions/product-protection-simple-offer.phtml
@@ -1,5 +1,5 @@
 <?php
-/** Hyva compatibility module - Product protection simple offer */
+/** Hyva compatibility module - Product protection simple offer  */
 
     /** @var Magento\Framework\Escaper $escaper */
     /** @var Magento\Catalog\Block\Product\View $block */
@@ -50,13 +50,15 @@
 </div>
 
     <script>
-           window.addEventListener(
-               'private-content-loaded', (event) => {
-                  initProductWarrantyOffers(event);
+    window.addEventListener(
+		   'private-content-loaded', (event) => {
+		   if (!window.extendLoaded){
+			   initProductWarrantyOffers(event);
+			   window.extendLoaded = true;
+		   }
                });
 
            async function initProductWarrantyOffers(event) {
-
                 const config = [{
                     extendStoreUuid: "<?= $block->getData('viewModel')->getExtendStoreUuid() ?>",
                     activeEnvironment: "<?= $block->getData('viewModel')->getActiveEnvironment() ?>",
@@ -65,8 +67,7 @@
                     productCategory: "<?= $categoryName; ?>",
                     currencyCode: "<?= $currencyCode ?>",
                     selectedConfigurableProduct: {}
-                }]
-
+	   }]
                 const customerData = event.detail.data;
 
                 let stringUtils = await import('<?= $stringUtils ?>');
@@ -133,48 +134,50 @@
                     }
                 }
 
-                function renderSimpleOffer(cartItems, config) {
-                    const sku = config[0].selectedProductSku
-                    const isWarrantyInCart = ExtendMagento.warrantyInCart({
-                        lineItemSku: sku,
-                        lineItems: cartItems,
-                    })
+		function renderSimpleOffer(cartItems, config) {
+                    const sku = cartItems.product_sku
 
-                    if (
-                        sku === 'extend-protection-plan' ||
-                        sku === 'xtd-pp-pln' ||
-                        isWarrantyInCart
-                    ) {
-                        return
+		 
+		    if (cartItems && cartItems.length > 0) { 
+			     
+			cartItems.forEach(cartItem => {
+                    		let isWarrantyInCart = ExtendMagento.warrantyInCart({
+                        	lineItemSku: cartItem.product_sku,
+                        	lineItems: cartItems,
+		                })
+			
+		    		if (
+                        		cartItem.product_sku === 'extend-protection-plan' ||
+                        		cartItem.product_sku === 'xtd-pp-pln' ||
+                        		isWarrantyInCart
+		    		) {
+                        		return
+				}
+
+
+                    		const activeProductData = {
+                        		referenceId: cartItem.product_sku,
+                        		price: Math.round(cartItem.product_price_value * 100),
+                        		onAddToCart: handleAddToCartClick,
+		     		}
+                    		if (!Extend.buttons.instance('#product_protection_offer_' +
+                        	stringUtils.sanitizeForElementId(cartItem.product_sku))){
+                        		window.Extend.buttons.renderSimpleOffer(
+                            		'#product_protection_offer_' +
+                            		stringUtils.sanitizeForElementId(cartItem.product_sku),
+                        	    	activeProductData,
+					)
+		    		}
+			})
                     }
 
-                    const activeProductData = {
-                        referenceId: config[0].selectedProductSku,
-                        price: Math.round(config[0].selectedProductPrice * 100),
-                        onAddToCart: handleAddToCartClick,
-                    }
-                    if (!Extend.buttons.instance('#product_protection_offer_' +
-                        stringUtils.sanitizeForElementId(config[0].selectedProductSku))){
-                        window.Extend.buttons.renderSimpleOffer(
-                            '#product_protection_offer_' +
-                            stringUtils.sanitizeForElementId(config[0].selectedProductSku),
-                            activeProductData,
-                        )
-                    }
+		}
+		const cartData  = cartUtils.getCartData()
+		const cartItems = cartData.items || cartUtils.getCartItems()
 
-                }
+		renderSimpleOffer(cartItems, config);
+		return 
 
-                return function() {
-                    const cartData  = cartUtils.getCartData()
-                    let cartItems = cartUtils.getCartItems()
-
-                    if (cartItems.length > 0) {
-                        renderSimpleOffer(cartItems, config)
-                    }
-
-                    cartItems = cartData.items
-                    renderSimpleOffer(cartItems, config)
-                }.bind(window.Extend, window.ExtendMagento)();
            }
     </script>
 

--- a/src/view/frontend/templates/cart/item/renderer/actions/product-protection-simple-offer.phtml
+++ b/src/view/frontend/templates/cart/item/renderer/actions/product-protection-simple-offer.phtml
@@ -50,13 +50,19 @@
 </div>
 
     <script>
+   if (!window.__hyvaExtendOffersInit){
     window.addEventListener(
-		   'private-content-loaded', (event) => {
-		   if (!window.extendLoaded){
-			   initProductWarrantyOffers(event);
-			   window.extendLoaded = true;
-		   }
-               });
+		   'private-content-loaded', async (event) => {
+    			try {
+        			await initProductWarrantyOffers(event);
+        			window.__hyvaExtendOffersInit = true;
+    			} catch (error) {
+        			console.error('Failed to initialize product warranty offers:', error);
+    			}
+
+   		});
+   }
+               
 
            async function initProductWarrantyOffers(event) {
                 const config = [{
@@ -127,16 +133,15 @@
                             listPrice,
                             offerId,
                             quantity: quantity ?? getProductQuantity(cartItems, product),
-                        }).then(function () {
-                            cartUtils.refreshMiniCart()
-                            window.location.reload()
+			}).then( async function () {
+				await cartUtils.refreshMiniCart();
+			 	window.location.reload();
                         })
                     }
                 }
 
 		function renderSimpleOffer(cartItems, config) {
                     const sku = cartItems.product_sku
-
 		 
 		    if (cartItems && cartItems.length > 0) { 
 			     

--- a/src/view/frontend/web/js/utils/cart-utils.js
+++ b/src/view/frontend/web/js/utils/cart-utils.js
@@ -19,9 +19,9 @@ window.cart_utils = (customerData) => {
         getCartData: function () {
             return customerData.cart;
         },
-        refreshMiniCart: function () {
-            hyva.setCookie('mage-cache-sessid', '', -1, true); // remove the cookie
-            window.dispatchEvent(new CustomEvent("reload-customer-section-data")); // reload the data
+        refreshMiniCart: async function () {
+            await hyva.setCookie('mage-cache-sessid', '', -1, true); // remove the cookie
+            await window.dispatchEvent(new CustomEvent("reload-customer-section-data")); // reload the data
         },
         mapToExtendCartItem: function (magentoCartItem) {
             return {


### PR DESCRIPTION
fixed a bug where offers only showed for the last/first item of the cart, and not the remaining items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced product protection offer handling to support multiple items in cart simultaneously, with individual warranty offers rendered per product.

* **Improvements**
  * Optimized offer initialization to prevent duplicate rendering and improve cart page performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->